### PR TITLE
specify a way to match url pathnames and avoid querystring issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ console.log(values); // [1, 3]
 
 ## Example: A complete HTTP router
 
-In this example the patterns module it's used as a simple but powerful
+In this example the patterns module is used as a simple but powerful
 HTTP route matcher:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ HTTP route matcher:
 
 ```js
 var http = require('http');
+var url = require('url');
 var patterns = require('patterns')();
 
 patterns.add('GET /foo', fn1);
@@ -131,7 +132,8 @@ patterns.add('GET /foo/{id}', fn2);
 patterns.add('POST /foo/{id}', fn3);
 
 http.createServer(function (req, res) {
-  var match = patterns.match(req.method + ' ' + req.url);
+  var path = url.parse(req.url).pathname
+  var match = patterns.match(req.method + ' ' + path);
 
   if (!match) {
     res.writeHead(404);


### PR DESCRIPTION
Greetings 👋👋

This is a mix of a README update and an inquiry for some advice on a problem I ran into.

**problem**: I make a route like `routes.add('GET /', renderHomePage)` but the link doesn't work when people add querystrings. This is typical when people use a platform like Buffer to share your link (Buffer adds a bunch of share meta data as a querystring parameter).

**solution**:  Though there a couple ways to handle this, the way that I feel is easiest to communicate is by only matching pathnames, rather than the whole req.url string.

example:

```
  var path = url.parse(req.url).pathname
  var match = patterns.match(req.method + ' ' + path);
```

Unless there is a better way to handle this that I'm missing.   I really like patterns and use it heavily (and recommend it to others).  Thanks for making it! 🌴
