### PR TITLE
Allow pattern to be function (eg. murl instance)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var Patterns = module.exports = function (patterns) {
 
 var compile = function (ptn) {
   if (typeof ptn === 'string') return murl(ptn)
+  if (typeof ptn === 'function') return ptn
   return function (target) {
     return target.match(ptn)
   }


### PR DESCRIPTION
This way I can pass in my own `murl` instances. This was just a quick idea, will write tests tomorrow